### PR TITLE
fix test_select_mult_w_when

### DIFF
--- a/jx_sqlite/__init__.py
+++ b/jx_sqlite/__init__.py
@@ -41,6 +41,8 @@ def unique_name():
 def column_key(k, v):
     if v == None:
         return None
+    elif isinstance(v, bool):
+        return k, "boolean"
     elif isinstance(v, basestring):
         return k, "string"
     elif isinstance(v, list):
@@ -56,6 +58,8 @@ def column_key(k, v):
 def get_type(v):
     if v == None:
         return None
+    elif isinstance(v, bool):
+        return "boolean"
     elif isinstance(v, basestring):
         return "string"
     elif isinstance(v, Mapping):
@@ -143,7 +147,7 @@ sql_types = {
     "string": "TEXT",
     "integer": "INTEGER",
     "number": "REAL",
-    "boolean": "INTEGER",
+    "boolean": "TINYINT",
     "object": "TEXT",
     "nested": "TEXT"
 }

--- a/jx_sqlite/query_table.py
+++ b/jx_sqlite/query_table.py
@@ -127,19 +127,8 @@ class QueryTable(AggsTable):
             op = self._set_op(query, frum)
             return op
 
-
-
         result = self.db.query(command)
-        res = self.db.query("""
-        SELECT "a.$number",
-            CASE 
-                WHEN "b.$boolean"
-                    THEN 0
-                ELSE 1
-                END
-        FROM testing __a__
-        """)
-        res2 = self.db.query("select * from testing")
+
         column_names = query.edges.name + query.groupby.name + listwrap(query.select).name
         if query.format == "container":
             output = QueryTable(new_table, db=self.db, uid=self.uid, exists=True)

--- a/jx_sqlite/query_table.py
+++ b/jx_sqlite/query_table.py
@@ -130,7 +130,16 @@ class QueryTable(AggsTable):
 
 
         result = self.db.query(command)
-        
+        res = self.db.query("""
+        SELECT "a.$number",
+            CASE 
+                WHEN "b.$boolean"
+                    THEN 0
+                ELSE 1
+                END
+        FROM testing __a__
+        """)
+        res2 = self.db.query("select * from testing")
         column_names = query.edges.name + query.groupby.name + listwrap(query.select).name
         if query.format == "container":
             output = QueryTable(new_table, db=self.db, uid=self.uid, exists=True)
@@ -338,9 +347,9 @@ class QueryTable(AggsTable):
 
         return output
 
-    def query_metadata(self, query):        
+    def query_metadata(self, query):
         Log.error("Not implemented yet")
-        
+
     def _window_op(self, query, window):
         # http://www2.sqlite.org/cvstrac/wiki?p=UnsupportedSqlAnalyticalFunctions
         if window.value == "rownum":

--- a/tests/test_jx/test_expressions_w_set_ops.py
+++ b/tests/test_jx/test_expressions_w_set_ops.py
@@ -339,17 +339,17 @@ class TestSetOps(BaseTestCase):
     def test_select_mult_w_when(self):
         test = {
             "data": [
-                {"a": 0, "b": False},
-                {"a": 1, "b": False},
-                {"a": 2, "b": True},
-                {"a": 3, "b": False},
-                {"a": 4, "b": True},
-                {"a": 5, "b": False},
-                {"a": 6, "b": True},
-                {"a": 7, "b": True},
-                {"a": 8},  # COUNTED, "b" IS NOT true
-                {"b": True},  # NOT COUNTED
-                {"b": False},  # NOT COUNTED
+                {"a": 0, "b": False},                  # 0*1
+                {"a": 1, "b": False},                  # 1*1 = 1
+                {"a": 2, "b": True},                   # 2*0
+                {"a": 3, "b": False},                  # 3*1 = 3
+                {"a": 4, "b": True},                   # 4*0
+                {"a": 5, "b": False},                  # 5*1 = 5
+                {"a": 6, "b": True},                   # 6*0
+                {"a": 7, "b": True},                   # 7*0
+                {"a": 8},  # COUNTED, "b" IS NOT true  # 8*1 = 8
+                {"b": True},  # NOT COUNTED              null * 0 = null
+                {"b": False},  # NOT COUNTED             null * 1 = null
             ],
             "query": {
                 "from": TEST_TABLE,


### PR DESCRIPTION
The [if clause](https://github.com/mozilla/jx-sqlite/compare/master...add_boolean?expand=1#diff-b72724739e0176e76f7efc00c5c0d7e6R282) did not have the correct implementation.

The problem was a lack of Boolean datatype tracking; `false` and `null` are both falsey values in the `when` clause.  

* `"boolean": "TINYINT",` for the future, when we want to read existing databases and find the columns with booleans.
* whitespace
* comments added to test
* add parenthesis, just in case expression are complex